### PR TITLE
closes 91: added config file

### DIFF
--- a/frontier/assets/config.json
+++ b/frontier/assets/config.json
@@ -1,0 +1,4 @@
+{
+    "environment": "DEV",
+    "logLevel": 3
+}

--- a/frontier/ci/env/prod/config.json
+++ b/frontier/ci/env/prod/config.json
@@ -1,0 +1,4 @@
+{
+    "environment": "PROD",
+    "logLevel": 0
+}

--- a/frontier/core/src/main/java/com/zhaw/frontier/FrontierGame.java
+++ b/frontier/core/src/main/java/com/zhaw/frontier/FrontierGame.java
@@ -3,7 +3,9 @@ package com.zhaw.frontier;
 import com.badlogic.gdx.Game;
 import com.badlogic.gdx.Screen;
 import com.badlogic.gdx.assets.AssetManager;
+import com.zhaw.frontier.configs.AppConfig;
 import com.zhaw.frontier.screens.LoadingScreen;
+import com.zhaw.frontier.utils.AppConfigLoader;
 import com.zhaw.frontier.wrappers.FrontierSpriteBatch;
 import com.zhaw.frontier.wrappers.SpriteBatchInterface;
 
@@ -11,11 +13,14 @@ public class FrontierGame extends Game {
 
     private SpriteBatchInterface batch;
     private AssetManager assetManager;
+    private AppConfig appConfig;
 
     @Override
     public void create() {
         batch = new FrontierSpriteBatch();
         assetManager = new AssetManager();
+
+        this.appConfig = AppConfigLoader.ReadAppConfig();
         this.setScreen(new LoadingScreen(this));
     }
 
@@ -39,5 +44,9 @@ public class FrontierGame extends Game {
 
     public AssetManager getAssetManager() {
         return assetManager;
+    }
+
+    public AppConfig getAppConfig() {
+        return appConfig;
     }
 }

--- a/frontier/core/src/main/java/com/zhaw/frontier/configs/AppConfig.java
+++ b/frontier/core/src/main/java/com/zhaw/frontier/configs/AppConfig.java
@@ -1,0 +1,37 @@
+package com.zhaw.frontier.configs;
+
+import com.zhaw.frontier.enums.AppEnvironment;
+
+/**
+ * Holds configuration settings for the application, such as the current environment
+ * and logging verbosity level.
+ */
+public class AppConfig {
+
+    private AppEnvironment environment;
+    private int logLevel;
+
+    /**
+     * Default constructor for {@code AppConfig}.
+     * Is needed for LibGDX JSON serialization
+     */
+    public AppConfig() {}
+
+    /**
+     * Gets the current application environment.
+     *
+     * @return the {@link AppEnvironment} the application is running in
+     */
+    public AppEnvironment getEnvironment() {
+        return environment;
+    }
+
+    /**
+     * Gets the configured logging level.
+     *
+     * @return the log level as an integer
+     */
+    public int getLogLevel() {
+        return logLevel;
+    }
+}

--- a/frontier/core/src/main/java/com/zhaw/frontier/enums/AppEnvironment.java
+++ b/frontier/core/src/main/java/com/zhaw/frontier/enums/AppEnvironment.java
@@ -1,0 +1,9 @@
+package com.zhaw.frontier.enums;
+
+/**
+ * Enum for the environment in which the application currently runs
+ */
+public enum AppEnvironment {
+    DEV,
+    PROD,
+}

--- a/frontier/core/src/main/java/com/zhaw/frontier/input/GameInputProcessor.java
+++ b/frontier/core/src/main/java/com/zhaw/frontier/input/GameInputProcessor.java
@@ -9,10 +9,12 @@ import com.badlogic.gdx.InputAdapter;
 import com.zhaw.frontier.FrontierGame;
 import com.zhaw.frontier.components.InventoryComponent;
 import com.zhaw.frontier.components.PositionComponent;
+import com.zhaw.frontier.configs.AppConfig;
 import com.zhaw.frontier.entityFactories.EnemyFactory;
 import com.zhaw.frontier.entityFactories.ResourceBuildingFactory;
 import com.zhaw.frontier.entityFactories.TowerFactory;
 import com.zhaw.frontier.entityFactories.WallFactory;
+import com.zhaw.frontier.enums.AppEnvironment;
 import com.zhaw.frontier.systems.BuildingManagerSystem;
 import com.zhaw.frontier.systems.EnemyManagementSystem;
 
@@ -28,6 +30,7 @@ public class GameInputProcessor extends InputAdapter {
 
     private final Engine engine;
     private final FrontierGame frontierGame;
+    private final AppConfig appConfig;
 
     /**
      * Constructs a new GameInputProcessor.
@@ -38,6 +41,7 @@ public class GameInputProcessor extends InputAdapter {
     public GameInputProcessor(Engine engine, FrontierGame frontierGame) {
         this.engine = engine;
         this.frontierGame = frontierGame;
+        this.appConfig = frontierGame.getAppConfig();
     }
 
     /**
@@ -71,6 +75,10 @@ public class GameInputProcessor extends InputAdapter {
 
         if (enemyManagementSystem == null) {
             Gdx.app.error("GameInputProcessor", "EnemyManagementSystem not found in engine!");
+            return false;
+        }
+
+        if (this.appConfig.getEnvironment() != AppEnvironment.DEV) {
             return false;
         }
 

--- a/frontier/core/src/main/java/com/zhaw/frontier/screens/GameScreen.java
+++ b/frontier/core/src/main/java/com/zhaw/frontier/screens/GameScreen.java
@@ -59,7 +59,7 @@ public class GameScreen implements Screen, ButtonClickObserver {
 
     @Override
     public void show() {
-        Gdx.app.setLogLevel(Application.LOG_DEBUG);
+        Gdx.app.setLogLevel(this.frontierGame.getAppConfig().getLogLevel());
         // setup up ecs(entity component system)
         Gdx.app.debug("[DEBUG] - GameScreen", "Initializing the engine.");
 

--- a/frontier/core/src/main/java/com/zhaw/frontier/utils/AppConfigLoader.java
+++ b/frontier/core/src/main/java/com/zhaw/frontier/utils/AppConfigLoader.java
@@ -1,0 +1,24 @@
+package com.zhaw.frontier.utils;
+
+import com.badlogic.gdx.Gdx;
+import com.badlogic.gdx.files.FileHandle;
+import com.badlogic.gdx.utils.Json;
+import com.zhaw.frontier.configs.AppConfig;
+
+/**
+ * Utility class for loading application configuration from a JSON file.
+ */
+public class AppConfigLoader {
+
+    /**
+     * Reads and parses the {@code config.json} file located in the internal assets directory.
+     *
+     * @return an {@link AppConfig} object populated with values from the JSON file
+     */
+    public static AppConfig ReadAppConfig() {
+        FileHandle file = Gdx.files.internal("config.json");
+        Json json = new Json();
+        AppConfig config = json.fromJson(AppConfig.class, file);
+        return config;
+    }
+}


### PR DESCRIPTION
This pull request introduces a new configuration system for the Frontier application, which includes setting up environment-specific configurations and integrating them throughout the codebase. The most important changes include adding configuration files, creating a new configuration class, and updating various parts of the application to use the new configuration system.

### Configuration Setup:

* [`frontier/assets/config.json`](diffhunk://#diff-ef1e5670638b9f043d4fdabae6a95a0b628dcaea316004896b464f364df88f15R1-R4): Added a new configuration file for the development environment with log level settings.
* [`frontier/ci/env/prod/config.json`](diffhunk://#diff-498ae7b89f56256be09bc2aae6e1a732d15e3657f600e2beb0cd66b3c7efacf1R1-R4): Added a new configuration file for the production environment with log level settings.

### New Configuration Classes:

* [`frontier/core/src/main/java/com/zhaw/frontier/configs/AppConfig.java`](diffhunk://#diff-7917f7a282df76877b57111dcbc50569159d17e8469b9d09f454455d475b915aR1-R37): Created a new `AppConfig` class to hold configuration settings such as environment and log level.
* [`frontier/core/src/main/java/com/zhaw/frontier/enums/AppEnvironment.java`](diffhunk://#diff-04ba4926a2e870663ae33482f480ca2aea95fbf458ca51281593074fc5d88bebR1-R10): Added an `AppEnvironment` enum to represent different application environments (DEV, PROD).
* [`frontier/core/src/main/java/com/zhaw/frontier/utils/AppConfigLoader.java`](diffhunk://#diff-1d832bec4303df0b18a475e0c4376f7c8c6be043efc0ce5bfe3d5518d155977eR1-R24): Added a utility class `AppConfigLoader` to read and parse the configuration file.

### Application Integration:

* [`frontier/core/src/main/java/com/zhaw/frontier/FrontierGame.java`](diffhunk://#diff-3e6a1c624328fa0636a3761a1b2f48fc1e38cbf3c4c1660ff4d406a7b32ec37fR6-R23): Integrated the new configuration system by loading the configuration in the `create` method and providing a getter for `AppConfig`. [[1]](diffhunk://#diff-3e6a1c624328fa0636a3761a1b2f48fc1e38cbf3c4c1660ff4d406a7b32ec37fR6-R23) [[2]](diffhunk://#diff-3e6a1c624328fa0636a3761a1b2f48fc1e38cbf3c4c1660ff4d406a7b32ec37fR47-R50)
* [`frontier/core/src/main/java/com/zhaw/frontier/input/GameInputProcessor.java`](diffhunk://#diff-b633b65279a75308ab464eb7edd9811125d46b4924bb53373b445bdf7a6c300bR10-R14): Updated the `GameInputProcessor` to use the new configuration system, including checking the environment before processing input. [[1]](diffhunk://#diff-b633b65279a75308ab464eb7edd9811125d46b4924bb53373b445bdf7a6c300bR10-R14) [[2]](diffhunk://#diff-b633b65279a75308ab464eb7edd9811125d46b4924bb53373b445bdf7a6c300bR29) [[3]](diffhunk://#diff-b633b65279a75308ab464eb7edd9811125d46b4924bb53373b445bdf7a6c300bR40) [[4]](diffhunk://#diff-b633b65279a75308ab464eb7edd9811125d46b4924bb53373b445bdf7a6c300bR67-R70)
* [`frontier/core/src/main/java/com/zhaw/frontier/screens/GameScreen.java`](diffhunk://#diff-03e312911f87ad6482a2c17f4e65a38bed8101cf715c709107516e3aa0efc626L49-R49): Modified the `GameScreen` to set the logging level based on the configuration.Fixes #

## Checklist (for code changes)

- [ ] added docs
- [ ] added tests

## Short description

<!-- add a short description of your changes so the reviewer knows what you intended to do -->
