### PR TITLE
CD changes

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -32,9 +32,13 @@ jobs:
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
           restore-keys: ${{ runner.os }}-gradle
 
+      - name: Extract version
+        id: extract_version
+        run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_ENV
+
       - name: build for all the platforms
         working-directory: ./frontier
-        run: ./gradlew :lwjgl3:packageMacM1 :lwjgl3:packageMacX64 :lwjgl3:packageWinX64 :lwjgl3:packageLinuxX64
+        run: ./gradlew flattenAllZips -Pversion=${{ env.VERSION }}
 
       - name: Release (prerelease)
         uses: softprops/action-gh-release@v2
@@ -50,5 +54,6 @@ jobs:
         if: (!contains(github.ref, '-alpha') && !contains(github.ref, '-beta'))
         with:
           generate_release_notes: true
+          make_latest: true
           files: |
             frontier/lwjgl3/build/construo/dist/Frontier-*.zip

--- a/frontier/build.gradle
+++ b/frontier/build.gradle
@@ -122,8 +122,11 @@ configure(subprojects) {
   }
 }
 
+
+version = project.hasProperty('version') ? project.getProperty('version') : '1.0.0'
+
 subprojects {
-  version = "$projectVersion"
+  version = project.version
   ext.appName = 'Frontier'
   repositories {
     mavenCentral()

--- a/frontier/lwjgl3/build.gradle
+++ b/frontier/lwjgl3/build.gradle
@@ -1,4 +1,3 @@
-
 buildscript {
     repositories {
         gradlePluginPortal()
@@ -57,7 +56,7 @@ run {
 
 jar {
     // sets the name of the .jar file this produces to the name of the game or app, with the version after.
-    archiveFileName.set("${appName}-${projectVersion}.jar")
+    archiveFileName.set("${appName}-${project.version}.jar")
     // the duplicatesStrategy matters starting in Gradle 7.0; this setting works.
     duplicatesStrategy(DuplicatesStrategy.EXCLUDE)
     dependsOn configurations.runtimeClasspath
@@ -87,7 +86,7 @@ construo {
     // human-readable name, used for example in the `.app` name for macOS
     humanName.set(appName)
     // Optional, defaults to project version property
-    version.set("$projectVersion")
+    version.set(project.version)
 
     targets.configure {
         create("linuxX64", Target.Linux) {
@@ -117,6 +116,10 @@ construo {
             //useConsole.set(true)
         }
     }
+}
+
+tasks.register("packageAll") {
+    dependsOn "packageWinX64", "packageLinuxX64", "packageMacX64", "packageMacM1"
 }
 
 // Equivalent to the jar task; here for compatibility with gdx-setup.


### PR DESCRIPTION
This pull request includes several changes to the build and release process for the project. The main focus is on extracting the version from the GitHub reference, updating the version handling in the Gradle build files, and introducing tasks to flatten ZIP files for different targets.

### Build and Release Process Improvements:

* [`.github/workflows/cd.yml`](diffhunk://#diff-ea3ea8c9932adc7ba8161ceda844fedd43b006848ef1140c050cbd7ea0788a18R35-R41): Added a step to extract the version from the GitHub reference and store it in the environment variables. Updated the build command to use the extracted version.

### Version Handling in Gradle:

* [`frontier/build.gradle`](diffhunk://#diff-fc360d0836611f8739b3f5a23e9847ed0379851f42bcbcc5b19fbf7957f0ba1fR125-R129): Updated the version handling to use the extracted version from the project properties, defaulting to '1.0.0' if not provided.
* [`frontier/lwjgl3/build.gradle`](diffhunk://#diff-ee79f56ef030f14c8483d16a566c87902772f84afd3d7c8c7bfd77160e320afdL60-R59): Updated various tasks to use `project.version` instead of `projectVersion` for consistency and correctness. [[1]](diffhunk://#diff-ee79f56ef030f14c8483d16a566c87902772f84afd3d7c8c7bfd77160e320afdL60-R59) [[2]](diffhunk://#diff-ee79f56ef030f14c8483d16a566c87902772f84afd3d7c8c7bfd77160e320afdL90-R89)

### ZIP File Flattening:

* [`frontier/lwjgl3/build.gradle`](diffhunk://#diff-ee79f56ef030f14c8483d16a566c87902772f84afd3d7c8c7bfd77160e320afdR121-R172): Introduced tasks to flatten ZIP files for different targets (winX64, macM1, macX64, linuxX64) and a task to run all flattening tasks at once.
