### PR TITLE
Fixed building menu not disappearing bug

### DIFF
--- a/frontier/core/src/main/java/com/zhaw/frontier/ui/BuildingMenuUi.java
+++ b/frontier/core/src/main/java/com/zhaw/frontier/ui/BuildingMenuUi.java
@@ -136,7 +136,7 @@ public class BuildingMenuUi implements Disposable, ButtonClickObserver {
 
     @Override
     public void buttonClicked(GameMode gameMode) {
-        if (GameMode.BUILDING == gameMode) {
+        if (GameMode.BUILDING == gameMode && !visible) {
             show();
         } else {
             hide();


### PR DESCRIPTION
Fixes #136 

## Checklist (for code changes)

- [ ] added docs
- [ ] added tests

## Short description

At the moment if you press the build button you enter the build mode. If you press the button again, you leave the build mode (you enter normal mode). However, the building menu does not reflect this. This PR fixes that small issue.