### PR TITLE
camera clamp so that only the map is visible

### DIFF
--- a/frontier/core/src/main/java/com/zhaw/frontier/configs/AppProperties.java
+++ b/frontier/core/src/main/java/com/zhaw/frontier/configs/AppProperties.java
@@ -41,4 +41,7 @@ public class AppProperties {
      * If the entity is within this distance from the waypoint, it is considered to have arrived.
      */
     public static final float PATH_FOLLOWER_STOP_TRESHOLD = 0.1f;
+
+    public static final float WORLD_HEIGHT = 64 * 16;
+    public static final float WORLD_WIDTH = 64 * 16;
 }

--- a/frontier/core/src/main/java/com/zhaw/frontier/input/RTSInputAdapter.java
+++ b/frontier/core/src/main/java/com/zhaw/frontier/input/RTSInputAdapter.java
@@ -35,7 +35,7 @@ public class RTSInputAdapter extends InputAdapter {
      */
     public RTSInputAdapter(ExtendViewport viewport) {
         this.viewport = viewport;
-        this.camera = (OrthographicCamera) viewport.getCamera() ;
+        this.camera = (OrthographicCamera) viewport.getCamera();
         // Initialize the camera target to the camera's starting position.
         this.cameraTarget = new Vector3(camera.position);
     }

--- a/frontier/core/src/main/java/com/zhaw/frontier/input/RTSInputAdapter.java
+++ b/frontier/core/src/main/java/com/zhaw/frontier/input/RTSInputAdapter.java
@@ -3,7 +3,6 @@ package com.zhaw.frontier.input;
 import com.badlogic.gdx.Gdx;
 import com.badlogic.gdx.Input;
 import com.badlogic.gdx.InputAdapter;
-import com.badlogic.gdx.graphics.Camera;
 import com.badlogic.gdx.graphics.OrthographicCamera;
 import com.badlogic.gdx.math.MathUtils;
 import com.badlogic.gdx.math.Vector3;
@@ -19,7 +18,7 @@ import com.badlogic.gdx.utils.viewport.ExtendViewport;
 public class RTSInputAdapter extends InputAdapter {
 
     private final ExtendViewport viewport;
-    private final Camera camera;
+    private final OrthographicCamera camera;
     private final Vector3 lastTouch = new Vector3();
     private final Vector3 currentTouch = new Vector3();
     private final Vector3 cameraTarget;
@@ -36,7 +35,7 @@ public class RTSInputAdapter extends InputAdapter {
      */
     public RTSInputAdapter(ExtendViewport viewport) {
         this.viewport = viewport;
-        this.camera = viewport.getCamera();
+        this.camera = (OrthographicCamera) viewport.getCamera() ;
         // Initialize the camera target to the camera's starting position.
         this.cameraTarget = new Vector3(camera.position);
     }
@@ -87,8 +86,9 @@ public class RTSInputAdapter extends InputAdapter {
             float deltaX = lastTouch.x - currentTouch.x;
             float deltaY = lastTouch.y - currentTouch.y;
             // Update the camera target by adding the delta.
+
             cameraTarget.add(deltaX, deltaY, 0);
-            // Update the last touch position for the next event.
+            this.clampCamera(camera, cameraTarget);
             lastTouch.set(currentTouch);
             return true;
         }
@@ -115,11 +115,29 @@ public class RTSInputAdapter extends InputAdapter {
         // Calculate the target zoom level.
         float targetZoom = camera.zoom + amountY * zoomSpeed;
         // Clamp the target zoom to a defined range.
-        targetZoom = MathUtils.clamp(targetZoom, 30f, 90f);
+        targetZoom = MathUtils.clamp(targetZoom, 30f, 60f);
         // Interpolate the camera's zoom toward the target zoom.
         camera.zoom = MathUtils.lerp(camera.zoom, targetZoom, smoothingFactor);
+        this.clampCamera(camera, cameraTarget);
+        this.clampCamera(camera, camera.position);
         camera.update();
         return true;
+    }
+
+    private void clampCamera(OrthographicCamera camera, Vector3 target) {
+        float width = camera.viewportWidth * camera.zoom;
+        float height = camera.viewportHeight * camera.zoom;
+        float w = width * Math.abs(camera.up.y) + height * Math.abs(camera.up.x);
+        float h = height * Math.abs(camera.up.y) + width * Math.abs(camera.up.x);
+
+        float minX = w / 2;
+        float minY = h / 2;
+        float mapWidth = 32 * 32;
+        float mapHeight = 32 * 32;
+        float maxX = mapWidth - (w / 2);
+        float maxY = mapHeight - (h / 2);
+        target.x = MathUtils.clamp(cameraTarget.x, minX, maxX);
+        target.y = MathUtils.clamp(cameraTarget.y, minY, maxY);
     }
 
     /**

--- a/frontier/core/src/main/java/com/zhaw/frontier/input/RTSInputAdapter.java
+++ b/frontier/core/src/main/java/com/zhaw/frontier/input/RTSInputAdapter.java
@@ -7,6 +7,7 @@ import com.badlogic.gdx.graphics.OrthographicCamera;
 import com.badlogic.gdx.math.MathUtils;
 import com.badlogic.gdx.math.Vector3;
 import com.badlogic.gdx.utils.viewport.ExtendViewport;
+import com.zhaw.frontier.configs.AppProperties;
 
 /**
  * An input adapter for real-time strategy (RTS) style camera controls.
@@ -132,10 +133,8 @@ public class RTSInputAdapter extends InputAdapter {
 
         float minX = w / 2;
         float minY = h / 2;
-        float mapWidth = 32 * 32;
-        float mapHeight = 32 * 32;
-        float maxX = mapWidth - (w / 2);
-        float maxY = mapHeight - (h / 2);
+        float maxX = AppProperties.WORLD_WIDTH - (w / 2);
+        float maxY = AppProperties.WORLD_HEIGHT - (h / 2);
         target.x = MathUtils.clamp(cameraTarget.x, minX, maxX);
         target.y = MathUtils.clamp(cameraTarget.y, minY, maxY);
     }

--- a/frontier/core/src/main/java/com/zhaw/frontier/systems/CameraControlSystem.java
+++ b/frontier/core/src/main/java/com/zhaw/frontier/systems/CameraControlSystem.java
@@ -9,6 +9,7 @@ import com.badlogic.gdx.graphics.OrthographicCamera;
 import com.badlogic.gdx.maps.tiled.renderers.OrthogonalTiledMapRenderer;
 import com.badlogic.gdx.utils.viewport.ExtendViewport;
 import com.badlogic.gdx.utils.viewport.Viewport;
+import com.zhaw.frontier.configs.AppProperties;
 import com.zhaw.frontier.entityFactories.CameraFactory;
 import com.zhaw.frontier.input.RTSInputAdapter;
 import com.zhaw.frontier.mappers.CameraMapper;
@@ -56,6 +57,7 @@ public class CameraControlSystem extends IteratingSystem {
         this.renderer = renderer;
         setUpGameCamera(viewport);
         inputAdapter = new RTSInputAdapter(viewport);
+
         Gdx.app.debug("CameraControlSystem", "initialized");
         Gdx.app.debug(
             "CameraControlSystem",
@@ -123,7 +125,7 @@ public class CameraControlSystem extends IteratingSystem {
         camera = new OrthographicCamera();
         camera.setToOrtho(false);
         // Set the camera's initial position (example: centered at 32*16, 32*16)
-        camera.position.set(32 * 16, 32 * 16, 0);
+        camera.position.set(AppProperties.WORLD_WIDTH / 2, AppProperties.WORLD_HEIGHT / 2, 0);
         // Set the initial zoom level of the camera.
         this.camera.zoom = 40.0f;
         // TODO: Configure camera properties through components in the future.


### PR DESCRIPTION
Fixes #145

## Short description
clamp the camera on move and zoom so that we don't see the black background