### PR TITLE
fixes issue that entire screen gets cleared then

### DIFF
--- a/frontier/core/src/main/java/com/zhaw/frontier/ui/BaseUI.java
+++ b/frontier/core/src/main/java/com/zhaw/frontier/ui/BaseUI.java
@@ -143,7 +143,7 @@ public class BaseUI implements ButtonClickObserver, TurnChangeListener {
             () -> {
                 buildButton.setChecked(false);
                 demolishButton.setChecked(false);
-                frontierGame.switchScreen(new PauseScreen(frontierGame, gameScreen));
+                frontierGame.switchScreenWithoutDispose(new PauseScreen(frontierGame, gameScreen));
                 System.out.println("Opening pause menu...");
             },
             null

--- a/frontier/core/src/test/java/com/zhaw/frontier/screens/BaseUITest.java
+++ b/frontier/core/src/test/java/com/zhaw/frontier/screens/BaseUITest.java
@@ -51,8 +51,8 @@ class BaseUITest {
         pauseButton.fire(event);
         event.setType(InputEvent.Type.touchUp);
 
-        verify(mockGame, never()).switchScreen(any());
+        verify(mockGame, never()).switchScreenWithoutDispose(any());
         pauseButton.fire(event);
-        verify(mockGame).switchScreen(any());
+        verify(mockGame).switchScreenWithoutDispose(any());
     }
 }


### PR DESCRIPTION
This fix ensures that the engine is not cleared when entering the pausescreen from the base ui button0
